### PR TITLE
feat: add whitespace before self closing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Output:
 - `indentation` (String, default=`'    '`) The value used for indentation.
 - `collapseContent` (Boolean, default=`false`] True to keep content in the same line as the element. Only works if element contains at least one text node
 - `lineSeparator` (String, default=`\r\n`) Specify the line separator to use
+- `whiteSpaceAtEndOfSelfclosingTag` (Boolean, default=false) to either end ad self closing tag with `<tag/>` or `<tag />`
 
 
 ## On The Browser

--- a/test/data7_white-space-on-closing-tag/xml1-input.xml
+++ b/test/data7_white-space-on-closing-tag/xml1-input.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget version="1.2.4">
+    <allow-intent href="tel:*"/>
+    <preference name="StatusBarBackgroundColor" value="#1FBBA5"/>
+    <hook src="ssd_hooks/afterBuild.js" type="after_build"/>
+    <plugin name="cordova-plugin-statusbar" spec="^2.4.2"/>
+    <plugin name="cordova-plugin-ionic-webview" spec="^2.0.0">
+        <variable name="ANDROID_SUPPORT_ANNOTATIONS_VERSION" value="27.+"/>
+    </plugin>
+    <plugin name="cordova-plugin-inappbrowser" spec="^3.1.0"/>
+</widget>

--- a/test/data7_white-space-on-closing-tag/xml1-output.xml
+++ b/test/data7_white-space-on-closing-tag/xml1-output.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget version="1.2.4">
+    <allow-intent href="tel:*" />
+    <preference name="StatusBarBackgroundColor" value="#1FBBA5" />
+    <hook src="ssd_hooks/afterBuild.js" type="after_build" />
+    <plugin name="cordova-plugin-statusbar" spec="^2.4.2" />
+    <plugin name="cordova-plugin-ionic-webview" spec="^2.0.0">
+        <variable name="ANDROID_SUPPORT_ANNOTATIONS_VERSION" value="27.+" />
+    </plugin>
+    <plugin name="cordova-plugin-inappbrowser" spec="^3.1.0" />
+</widget>

--- a/test/index.js
+++ b/test/index.js
@@ -48,5 +48,9 @@ describe('XML formatter', function () {
     it('should format XML that already contains line breaks', function(done) {
         assertFormat('test/data6/xml*-input.xml', {}, done);
     });
+  
+      it('should format XML adding a whitespace before self closing tag', function(done) {
+        assertFormat('test/data7_white-space-on-closing-tag/xml*-input.xml', {whiteSpaceAtEndOfSelfclosingTag: true}, done);
+    });
 
 });


### PR DESCRIPTION
This PR add an new option `whiteSpaceAtEndOfSelfclosingTag` to add a white space to the end of an self closed tag;

without new option
```
<selfclosing param="test"/>
```
with new option
```
<selfclosing param="test" />
```