### PR TITLE
Make 'filter' option optional.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 type FormatOptions = {
     indentation?: string;
-    filter: (node: any) => boolean;
+    filter?: (node: any) => boolean;
     stripComments?: boolean;
     collapseContent?: boolean;
     lineSeparator?: string;


### PR DESCRIPTION
The type definitions introduced in version 2.1.1 made the `filter` option mandatory. I don't think you meant to do this!