### PR TITLE
Escape double quote in attribute value

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,9 +131,8 @@ function processElementNode(node, state, preserveSpace) {
  */
 function processAttributes(state, attributes) {
     Object.keys(attributes).forEach(function(attr) {
-        const value = attributes[attr];
-        const quote = value.indexOf('"') !== -1 ? '\'' : '"';
-        appendContent(state, ' ' + attr + '=' + quote + value + quote);
+        const escaped = attributes[attr].replace(/"/g, '&quot;');
+        appendContent(state, ' ' + attr + '="' + escaped + '"');
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -131,7 +131,9 @@ function processElementNode(node, state, preserveSpace) {
  */
 function processAttributes(state, attributes) {
     Object.keys(attributes).forEach(function(attr) {
-        appendContent(state, ' ' + attr + '="' + attributes[attr] + '"');
+        const value = attributes[attr];
+        const quote = value.indexOf('"') !== -1 ? '\'' : '"';
+        appendContent(state, ' ' + attr + '=' + quote + value + quote);
     });
 }
 

--- a/test/data8/xml1-input.xml
+++ b/test/data8/xml1-input.xml
@@ -1,0 +1,1 @@
+<article headline='Final season of "Lost" premieres on Tuesday'/>

--- a/test/data8/xml1-output.xml
+++ b/test/data8/xml1-output.xml
@@ -1,0 +1,1 @@
+<article headline='Final season of "Lost" premieres on Tuesday'/>

--- a/test/data8/xml1-output.xml
+++ b/test/data8/xml1-output.xml
@@ -1,1 +1,1 @@
-<article headline='Final season of "Lost" premieres on Tuesday'/>
+<article headline="Final season of &quot;Lost&quot; premieres on Tuesday"/>

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,10 @@ describe('XML formatter', function () {
         assertFormat('test/data4/xml*-input.xml', {}, done);
     });
 
+    it('should use single quotes for attribute that contains unescaped double quote', function(done) {
+        assertFormat('test/data8/xml*-input.xml', {}, done);
+    });
+
     it('should format XML with the custom line separator', function(done) {
         assertFormat('test/data5/xml*-input.xml', {lineSeparator: '\n'}, done);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -43,7 +43,7 @@ describe('XML formatter', function () {
         assertFormat('test/data4/xml*-input.xml', {}, done);
     });
 
-    it('should use single quotes for attribute that contains unescaped double quote', function(done) {
+    it('should escape a double quote in an attribute value', function(done) {
         assertFormat('test/data8/xml*-input.xml', {}, done);
     });
 


### PR DESCRIPTION
xml-parser-xo allows an attribute value to be enclosed in single quotes. In that case, the value may contain an unescaped double quote.