### PR TITLE
Fixed bug with formatting XML when there's a space between children tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ function processElementNode(node: XmlParserElementNode, state: XMLFormatterState
                             child.content = '';
                         }
                     }
-                    if (child.content.length > 0) {
+                    if (child.content.trim().length > 0) {
                         containsTextNodes = true;
                     }
                 } else if (child.type === 'CDATA') {

--- a/test/data12/xml1-input.xml
+++ b/test/data12/xml1-input.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?> <el> <param>Code</param> <param2>Code2</param2> </el>

--- a/test/data12/xml1-output.xml
+++ b/test/data12/xml1-output.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<el>
+    <param>Code</param>
+    <param2>Code2</param2>
+</el>

--- a/test/data13/xml1-input.xml
+++ b/test/data13/xml1-input.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?> <el> <param>Code</param> <param2>Code2</param2> </el>

--- a/test/data13/xml1-output.xml
+++ b/test/data13/xml1-output.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<el>
+    <param>
+        Code
+    </param>
+    <param2>
+        Code2
+    </param2>
+</el>

--- a/test/index.ts
+++ b/test/index.ts
@@ -116,4 +116,11 @@ describe('XML formatter', function () {
         assertFormatError('test/data10/xml*-input.xml', {throwOnFailure: false});
     });
 
+    context('should format XML with spaces between tags when collapseContent=true', function() {
+        assertFormat('test/data12/xml*-input.xml', {collapseContent: true});
+    });
+
+    context('should format XML with spaces between tags when collapseContent=false', function() {
+        assertFormat('test/data12/xml*-input.xml', {collapseContent: true});
+    });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -121,6 +121,6 @@ describe('XML formatter', function () {
     });
 
     context('should format XML with spaces between tags when collapseContent=false', function() {
-        assertFormat('test/data12/xml*-input.xml', {collapseContent: true});
+        assertFormat('test/data13/xml*-input.xml', {collapseContent: false});
     });
 });


### PR DESCRIPTION
Hello, I'm using your library in my work. Today I found a bug, where XML contains spaces between children tags. I've isolated it.
That XML:
```xml
<?xml version="1.0" encoding="UTF-8"?> <el> <param>Code</param> <param2>Code2</param2> </el>
```
was formatted incorrectly:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<el><param>Code</param> <param2>Code2</param2></el>
```
instead of
```xml
<?xml version="1.0" encoding="UTF-8"?>
<el>
    <param>Code</param>
    <param2>Code2</param2>
</el>
```
I've managed to find the issue, fixed it, and added tests to cover my fix. Now, everything is working well.
I'm looking forward your approval.

Regards