### PR TITLE
add option forceSelfClosingEmptyTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ This can be a partial path (element tag name) or full path starting from the doc
 - `throwOnFailure`: Throw an error when XML fails to parse and get formatted otherwise the original XML is returned.
   - type: `boolean`
   - default: `true`
+- `forceSelfClosingEmptyTag`: True to force empty tags to be self-closing.
+  - type: `boolean`
+  - default: `false`
 
 ### Usage:
  

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ export type FormatOptions = {
     collapseContent?: boolean;
     lineSeparator?: string;
     whiteSpaceAtEndOfSelfclosingTag?: boolean;
+    forceSelfClosingEmptyTag?: boolean;
 }
 
 declare function format(xml: string, options?: FormatOptions): string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,11 @@ export type XMLFormatterOptions = {
      * True to throw an error when parsing XML document with invalid content like mismatched closing tags.
      */
     strictMode?: boolean;
+
+    /**
+     * True to force empty tags to be self-closing.
+     */
+    forceSelfClosingEmptyTag?: boolean;
 };
 
 export type XMLFormatterMinifyOptions = Omit<XMLFormatterOptions, 'lineSeparator'|'indentation'>;
@@ -132,7 +137,7 @@ function processElementNode(node: XmlParserElementNode, state: XMLFormatterState
     appendContent(state, '<' + node.name);
     processAttributes(state, node.attributes);
 
-    if (node.children === null) {
+    if (node.children === null || (state.options.forceSelfClosingEmptyTag && node.children.length === 0)) {
         const selfClosingNodeClosingTag = state.options.whiteSpaceAtEndOfSelfclosingTag ? ' />' : '/>'
         // self-closing node
         appendContent(state, selfClosingNodeClosingTag);

--- a/test/data15/xml1-input.xml
+++ b/test/data15/xml1-input.xml
@@ -1,0 +1,1 @@
+<root><!-- test --><frag><p xml:space="preserve">This is <b>some</b> <b>some2</b> content</p></frag><empty></empty></root>

--- a/test/data15/xml1-output.xml
+++ b/test/data15/xml1-output.xml
@@ -1,0 +1,7 @@
+<root>
+    <!-- test -->
+    <frag>
+        <p xml:space="preserve">This is <b>some</b> <b>some2</b> content</p>
+    </frag>
+    <empty/>
+</root>

--- a/test/index.ts
+++ b/test/index.ts
@@ -131,4 +131,8 @@ describe('XML formatter', function () {
         });
     });
 
+    context('should collapse empty tags when forceSelfClosingEmptyTag=true', function () {
+        assertFormat('test/data15/xml*-input.xml', { forceSelfClosingEmptyTag: true });
+    });
+
 });


### PR DESCRIPTION
Hello,
I couldn't find a option to force the self-closing of empty tags, so I decided to do my first contribution on github.
I hope it works well :)

Option: `forceSelfClosingEmptyTag`

Input:
```xml
<root>
    <empty></empty>
</root>
```

Output:
```xml
<root>
    <empty/>
</root>
```

Kind regards
Constantin