### PR TITLE
Fix for styled space being removed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ function processElementNode(node: XmlParserElementNode, state: XMLFormatterState
                     if (child.content.includes('\n')) {
                         containsTextNodesWithLineBreaks = true;
                         child.content = child.content.trim();
-                    } else if (index === 0 || index === nodeChildren.length - 1) {
+                    } else if ((index === 0 || index === nodeChildren.length - 1) && !preserveSpace) {
                         if (child.content.trim().length === 0) {
                             // If the text node is at the start or end and is empty, it should be ignored when formatting
                             child.content = '';

--- a/test/data12/xml2-input.xml
+++ b/test/data12/xml2-input.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><root><content xml:space="preserve"><b><u>text1</u></b><b> </b><b><u>text2</u></b></content></root>

--- a/test/data12/xml2-output.xml
+++ b/test/data12/xml2-output.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+    <content xml:space="preserve"><b><u>text1</u></b><b> </b><b><u>text2</u></b></content>
+</root>

--- a/test/index.ts
+++ b/test/index.ts
@@ -134,5 +134,9 @@ describe('XML formatter', function () {
     context('should collapse empty tags when forceSelfClosingEmptyTag=true', function () {
         assertFormat('test/data15/xml*-input.xml', { forceSelfClosingEmptyTag: true });
     });
+    
+    context('should not remove space with style before differently stylised word when prettifying xml', function () {
+        assertFormat('test/data16/xml*-input.xml', { collapseContent: true });
+    });
 
 });


### PR DESCRIPTION
Fix for styled space being trimmed when the following word is styled differently, even when within a preserved parent.